### PR TITLE
7874 cache cms articles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,6 @@ group :test do
   gem 'rspec-core'
   gem 'factory_girl_rails'
   gem 'database_cleaner'
-  gem 'faker', '~> 1.6.0'
+  gem 'faker', '~> 1.7'
   gem 'pry-byebug'
 end

--- a/comfortable_mexican_sofa.gemspec
+++ b/comfortable_mexican_sofa.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails',             '>= 4.0.0', '<= 4.1.16'
   s.add_dependency 'rails-i18n',        '~> 4.0.0'
-  s.add_dependency 'i18n',              '~> 0.6.11'
+  s.add_dependency 'i18n',              '~> 0.7'
   s.add_dependency 'bootstrap_form',    '~> 2.1.1'
   s.add_dependency 'active_link_to',    '>= 1.0.0'
   s.add_dependency 'paperclip',         '>= 4.0.0'
-  s.add_dependency 'kramdown',          '>= 1.0.0'
+  s.add_dependency 'kramdown',          '~> 1.5'
   s.add_dependency 'jquery-rails',      '>= 3.0.0'
   s.add_dependency 'jquery-ui-rails',   '>= 5.0.0'
   s.add_dependency 'haml-rails',        '>= 0.3.0'

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
-File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/db/migrate/01_create_cms.rb
+++ b/db/migrate/01_create_cms.rb
@@ -67,6 +67,7 @@ class CreateCms < ActiveRecord::Migration
     create_table :comfy_cms_blocks do |t|
       t.string     :identifier,  :null => false
       t.text       :content,     text_limit
+      t.text       :processed_content, text_limit
       t.references :blockable, :polymorphic => true
       t.timestamps
     end

--- a/lib/comfortable_mexican_sofa/extensions/cms_manageable.rb
+++ b/lib/comfortable_mexican_sofa/extensions/cms_manageable.rb
@@ -1,11 +1,11 @@
 # ActsAsCms is the module that drives all the logic around blocks and
 # blocks_attributes.
 module ComfortableMexicanSofa::CmsManageable
-  
+
   def self.included(base)
     base.send :extend, ClassMethods
   end
-  
+
   module ClassMethods
 
     def cms_manageable
@@ -20,13 +20,13 @@ module ComfortableMexicanSofa::CmsManageable
         :dependent  => :destroy,
         :as         => :blockable,
         :class_name => 'Comfy::Cms::Block'
-        
+
       # -- Callbacks --------------------------------------------------------
       before_save :clear_content_cache
 
     end
   end
-  
+
   module InstanceMethods
 
     # Transforms existing cms_block information into a hash that can be used
@@ -39,7 +39,7 @@ module ComfortableMexicanSofa::CmsManageable
         block_attr
       end
     end
-    
+
     # Array of block hashes in the following format:
     #   [
     #     { :identifier => 'block_1', :content => 'block content' },
@@ -49,20 +49,21 @@ module ComfortableMexicanSofa::CmsManageable
       block_hashes = block_hashes.values if block_hashes.is_a?(Hash)
       block_hashes.each do |block_hash|
         block_hash.symbolize_keys! unless block_hash.is_a?(HashWithIndifferentAccess)
-        block = 
-          self.blocks.detect{|b| b.identifier == block_hash[:identifier]} || 
+        block =
+          self.blocks.detect{|b| b.identifier == block_hash[:identifier]} ||
           self.blocks.build(:identifier => block_hash[:identifier])
         block.content = block_hash[:content]
+        block.processed_content = block_hash[:processed_content]
         self.blocks_attributes_changed = self.blocks_attributes_changed || block.content_changed?
       end
     end
 
-    # Processing content will return rendered content and will populate 
+    # Processing content will return rendered content and will populate
     # self.cms_tags with instances of CmsTag
     def render
       @tags = [] # resetting
       return '' unless layout
-      
+
       ComfortableMexicanSofa::Tag.process_content(
         self, ComfortableMexicanSofa::Tag.sanitize_irb(layout.merged_content)
       )
@@ -92,11 +93,11 @@ module ComfortableMexicanSofa::CmsManageable
       end
       @content_cache
     end
-    
+
     def clear_content_cache!
       self.update_column(:content_cache, nil)
     end
-    
+
     def clear_content_cache
       write_attribute(:content_cache, nil) if self.has_attribute?(:content_cache)
     end

--- a/lib/comfortable_mexican_sofa/extensions/cms_manageable.rb
+++ b/lib/comfortable_mexican_sofa/extensions/cms_manageable.rb
@@ -49,13 +49,16 @@ module ComfortableMexicanSofa::CmsManageable
       block_hashes = block_hashes.values if block_hashes.is_a?(Hash)
       block_hashes.each do |block_hash|
         block_hash.symbolize_keys! unless block_hash.is_a?(HashWithIndifferentAccess)
-        block =
-          self.blocks.detect{|b| b.identifier == block_hash[:identifier]} ||
-          self.blocks.build(:identifier => block_hash[:identifier])
+        block = find_or_initialize_block(block_hash)
         block.content = block_hash[:content]
         block.processed_content = block_hash[:processed_content]
         self.blocks_attributes_changed = self.blocks_attributes_changed || block.content_changed?
       end
+    end
+
+    def find_or_initialize_block(block_hash)
+      self.blocks.detect { |b| b.identifier == block_hash[:identifier] } ||
+      self.blocks.build(identifier: block_hash[:identifier])
     end
 
     # Processing content will return rendered content and will populate

--- a/lib/comfortable_mexican_sofa/extensions/cms_manageable.rb
+++ b/lib/comfortable_mexican_sofa/extensions/cms_manageable.rb
@@ -36,6 +36,7 @@ module ComfortableMexicanSofa::CmsManageable
         block_attr = {}
         block_attr[:identifier] = block.identifier
         block_attr[:content]    = was ? block.content_was : block.content
+        block_attr[:processed_content] = block.processed_content if block.processed_content.present?
         block_attr
       end
     end

--- a/lib/comfortable_mexican_sofa/fixture/category.rb
+++ b/lib/comfortable_mexican_sofa/fixture/category.rb
@@ -6,7 +6,7 @@ module ComfortableMexicanSofa::Fixture::Category
         'pages'     => 'Comfy::Cms::Page',
         'snippets'  => 'Comfy::Cms::Snippet'
       }.each do |file, type|
-        if File.exists?(attrs_path = File.join(path, "#{file}.yml"))
+        if File.exist?(attrs_path = File.join(path, "#{file}.yml"))
           categories = get_attributes(attrs_path)
           [categories].flatten.each do |label|
             self.site.categories.find_or_create_by(:label => label, :categorized_type => type)

--- a/lib/comfortable_mexican_sofa/fixture/file.rb
+++ b/lib/comfortable_mexican_sofa/fixture/file.rb
@@ -7,7 +7,7 @@ module ComfortableMexicanSofa::Fixture::File
         
         # setting attributes
         categories = []
-        if File.exists?(attrs_path = File.join(self.path, "_#{filename}.yml"))
+        if File.exist?(attrs_path = File.join(self.path, "_#{filename}.yml"))
           if fresh_fixture?(file, attrs_path)
             attrs = get_attributes(attrs_path)
             
@@ -69,7 +69,7 @@ module ComfortableMexicanSofa::Fixture::File
           file.file.path :
           file.file.url
         
-        unless ::File.exists?(data_path)
+        unless ::File.exist?(data_path)
           ComfortableMexicanSofa.logger.warn("[FIXTURES] No physical File \t #{file.file_file_name}")
           next
         end

--- a/lib/comfortable_mexican_sofa/fixture/layout.rb
+++ b/lib/comfortable_mexican_sofa/fixture/layout.rb
@@ -9,7 +9,7 @@ module ComfortableMexicanSofa::Fixture::Layout
         layout.parent = parent
         
         # setting attributes
-        if File.exists?(attrs_path = File.join(path, 'attributes.yml'))
+        if File.exist?(attrs_path = File.join(path, 'attributes.yml'))
           if fresh_fixture?(layout, attrs_path)
             attrs = get_attributes(attrs_path)
             layout.label      = attrs['label']
@@ -20,7 +20,7 @@ module ComfortableMexicanSofa::Fixture::Layout
         
         # setting content
         %w(html haml).each do |extension|
-          if File.exists?(content_path = File.join(path, "content.#{extension}"))
+          if File.exist?(content_path = File.join(path, "content.#{extension}"))
             if fresh_fixture?(layout, content_path)
               layout.content = extension == "html" ? 
                 ::File.open(content_path).read : 
@@ -29,12 +29,12 @@ module ComfortableMexicanSofa::Fixture::Layout
           end
         end
         
-        if File.exists?(content_path = File.join(path, 'stylesheet.css'))
+        if File.exist?(content_path = File.join(path, 'stylesheet.css'))
           if fresh_fixture?(layout, content_path)
             layout.css = File.open(content_path).read
           end
         end
-        if File.exists?(content_path = File.join(path, 'javascript.js'))
+        if File.exist?(content_path = File.join(path, 'javascript.js'))
           if fresh_fixture?(layout, content_path)
             layout.js = File.open(content_path).read
           end

--- a/lib/comfortable_mexican_sofa/fixture/page.rb
+++ b/lib/comfortable_mexican_sofa/fixture/page.rb
@@ -15,7 +15,7 @@ module ComfortableMexicanSofa::Fixture::Page
 
         # setting attributes
         categories = []
-        if File.exists?(attrs_path = File.join(path, 'attributes.yml'))
+        if File.exist?(attrs_path = File.join(path, 'attributes.yml'))
           if fresh_fixture?(page, attrs_path)
             attrs = get_attributes(attrs_path)
 

--- a/lib/comfortable_mexican_sofa/fixture/snippet.rb
+++ b/lib/comfortable_mexican_sofa/fixture/snippet.rb
@@ -8,7 +8,7 @@ module ComfortableMexicanSofa::Fixture::Snippet
         
         # setting attributes
         categories = []
-        if File.exists?(attrs_path = File.join(path, 'attributes.yml'))
+        if File.exist?(attrs_path = File.join(path, 'attributes.yml'))
           if fresh_fixture?(snippet, attrs_path)
             attrs = get_attributes(attrs_path)
             
@@ -19,7 +19,7 @@ module ComfortableMexicanSofa::Fixture::Snippet
         
         # setting content
         %w(html haml).each do |extension|
-          if File.exists?(content_path = File.join(path, "content.#{extension}"))
+          if File.exist?(content_path = File.join(path, "content.#{extension}"))
             if fresh_fixture?(snippet, content_path)
               snippet.content = extension == "html" ? 
                 ::File.open(content_path).read : 

--- a/lib/tasks/gem.rake
+++ b/lib/tasks/gem.rake
@@ -1,7 +1,7 @@
 def load_gem_configs
   if defined?(Rails)
     mas_build_config_file = "#{::Rails.root}/config/mas-build"
-    require_relative(mas_build_config_file) if File.exists?(mas_build_config_file + '.rb')
+    require_relative(mas_build_config_file) if File.exist?(mas_build_config_file + '.rb')
   end
 end
 

--- a/test/controllers/comfy/cms/content_controller_test.rb
+++ b/test/controllers/comfy/cms/content_controller_test.rb
@@ -36,10 +36,10 @@ class Comfy::Cms::ContentControllerTest < ActionController::TestCase
 
     json_response = JSON.parse(response.body)
     assert_equal page.layout.identifier,  json_response['layout_identifier']
-    assert_equal nil,                     json_response['parent_id']
-    assert_equal nil,                     json_response['target_page_id']
+    assert_nil                      json_response['parent_id']
+    assert_nil                      json_response['target_page_id']
     assert_equal 'Default Page',          json_response['label']
-    assert_equal nil,                     json_response['slug']
+    assert_nil                      json_response['slug']
     assert_equal '/',                     json_response['full_path']
     assert_equal page.block_content,      json_response['blocks'].find {|b| b['identifier'] == 'content'}['content']
     assert_equal true,                    json_response['is_published']
@@ -185,7 +185,7 @@ class Comfy::Cms::ContentControllerTest < ActionController::TestCase
     json_response = JSON.parse(response.body)
     assert_equal page.layout.identifier,  json_response['layout_identifier']
     assert_equal 'Default Page',          json_response['label']
-    assert_equal nil,                     json_response['slug']
+    assert_nil                      json_response['slug']
     assert_equal '/',                     json_response['full_path']
     assert_equal page.block_content,      json_response['blocks'].find {|b| b['identifier'] == 'content'}['content']
     assert_equal true,                    json_response['is_published']

--- a/test/fixtures/comfy/cms/blocks.yml
+++ b/test/fixtures/comfy/cms/blocks.yml
@@ -2,6 +2,7 @@ default_field_text:
   blockable: default (Comfy::Cms::Page)
   identifier: default_field_text
   content: default_field_text_content
+  processed_content: default_field_text_cached_content
 
 default_page_text:
   blockable: default (Comfy::Cms::Page)

--- a/test/lib/configuration_test.rb
+++ b/test/lib/configuration_test.rb
@@ -18,14 +18,14 @@ class ConfigurationTest < ActiveSupport::TestCase
       'en'    => 'English',
       'es'    => 'Español'
     }), config.locales
-    assert_equal nil, config.admin_locale
+    assert_nil  config.admin_locale
     assert_equal ({}), config.upload_file_options
-    assert_equal nil, config.admin_cache_sweeper
+    assert_nil  config.admin_cache_sweeper
     assert_equal false, config.allow_irb
-    assert_equal nil, config.allowed_helpers
-    assert_equal nil, config.allowed_partials
-    assert_equal nil, config.hostname_aliases
-    assert_equal nil, config.preview_domain
+    assert_nil  config.allowed_helpers
+    assert_nil  config.allowed_partials
+    assert_nil  config.hostname_aliases
+    assert_nil  config.preview_domain
   end
 
   def test_initialization_overrides

--- a/test/lib/fixtures/files_test.rb
+++ b/test/lib/fixtures/files_test.rb
@@ -86,8 +86,8 @@ class FixtureFilesTest < ActiveSupport::TestCase
       returns(File.join(Rails.root, 'db/cms_fixtures/sample-site/files/sample.jpg'))
     ComfortableMexicanSofa::Fixture::File::Exporter.new('default-site', 'test-site').export!
     
-    assert File.exists?(attr_path)
-    assert File.exists?(file_path)
+    assert File.exist?(attr_path)
+    assert File.exist?(file_path)
     assert_equal ({
       'label'       => 'Default File',
       'description' => 'Default Description',

--- a/test/lib/fixtures/layouts_test.rb
+++ b/test/lib/fixtures/layouts_test.rb
@@ -101,15 +101,15 @@ class FixtureLayoutsTest < ActiveSupport::TestCase
     
     ComfortableMexicanSofa::Fixture::Layout::Exporter.new('default-site', 'test-site').export!
     
-    assert File.exists?(layout_1_attr_path)
-    assert File.exists?(layout_1_content_path)
-    assert File.exists?(layout_1_css_path)
-    assert File.exists?(layout_1_js_path)
+    assert File.exist?(layout_1_attr_path)
+    assert File.exist?(layout_1_content_path)
+    assert File.exist?(layout_1_css_path)
+    assert File.exist?(layout_1_js_path)
     
-    assert File.exists?(layout_2_attr_path)
-    assert File.exists?(layout_2_content_path)
-    assert File.exists?(layout_2_css_path)
-    assert File.exists?(layout_2_js_path)
+    assert File.exist?(layout_2_attr_path)
+    assert File.exist?(layout_2_content_path)
+    assert File.exist?(layout_2_css_path)
+    assert File.exist?(layout_2_js_path)
     
     assert_equal ({
       'label'       => 'Nested Layout',

--- a/test/lib/fixtures/pages_test.rb
+++ b/test/lib/fixtures/pages_test.rb
@@ -73,7 +73,7 @@ class FixturePagesTest < ActiveSupport::TestCase
     ComfortableMexicanSofa::Fixture::Page::Importer.new('sample-site', 'default-site').import!
     page.reload
     
-    assert_equal nil, page.slug
+    assert_nil  page.slug
     assert_equal 'Test', page.label
     block = page.blocks.where(:identifier => 'content').first
     assert_equal 'test content', block.content

--- a/test/lib/fixtures/snippets_test.rb
+++ b/test/lib/fixtures/snippets_test.rb
@@ -87,8 +87,8 @@ class FixtureSnippetsTest < ActiveSupport::TestCase
     
     ComfortableMexicanSofa::Fixture::Snippet::Exporter.new('default-site', 'test-site').export!
     
-    assert File.exists?(attr_path)
-    assert File.exists?(content_path)
+    assert File.exist?(attr_path)
+    assert File.exist?(content_path)
     assert_equal ({
       'label'       => 'Default Snippet',
       'categories'  => ['Default']

--- a/test/lib/tag_test.rb
+++ b/test/lib/tag_test.rb
@@ -6,55 +6,55 @@ class TagTest < ActiveSupport::TestCase
     regex = ComfortableMexicanSofa::Tag::TOKENIZER_REGEX
     
     tokens = 'text { text } text'.scan(regex)
-    assert_equal nil,                   tokens[0][0]
+    assert_nil                    tokens[0][0]
     assert_equal 'text { text } text',  tokens[0][1]
     
     tokens = 'content<{{cms:some_tag content'.scan(regex)
-    assert_equal nil,                     tokens[0][0]
+    assert_nil                      tokens[0][0]
     assert_equal 'content<',              tokens[0][1]
-    assert_equal nil,                     tokens[1][0]
+    assert_nil                      tokens[1][0]
     assert_equal '{{',                    tokens[1][1]
-    assert_equal nil,                     tokens[2][0]
+    assert_nil                      tokens[2][0]
     assert_equal 'cms:some_tag content',  tokens[2][1]
     
     tokens = 'content<{{cms some_tag}}>content'.scan(regex)
-    assert_equal nil,                     tokens[0][0]
+    assert_nil                      tokens[0][0]
     assert_equal 'content<',              tokens[0][1]
-    assert_equal nil,                     tokens[1][0]
+    assert_nil                      tokens[1][0]
     assert_equal '{{',                    tokens[1][1]
-    assert_equal nil,                     tokens[2][0]
+    assert_nil                      tokens[2][0]
     assert_equal 'cms some_tag}}>content',tokens[2][1]
     
     tokens = 'content<{{cms:some_tag}}>content'.scan(regex)
-    assert_equal nil,                     tokens[0][0]
+    assert_nil                      tokens[0][0]
     assert_equal 'content<',              tokens[0][1]
     assert_equal '{{cms:some_tag}}',      tokens[1][0]
-    assert_equal nil,                     tokens[1][1]
-    assert_equal nil,                     tokens[2][0]
+    assert_nil                      tokens[1][1]
+    assert_nil                      tokens[2][0]
     assert_equal '>content',              tokens[2][1]
     
     tokens = 'content<{{cms:type:label}}>content'.scan(regex)
-    assert_equal nil,                     tokens[0][0]
+    assert_nil                      tokens[0][0]
     assert_equal 'content<',              tokens[0][1]
     assert_equal '{{cms:type:label}}',    tokens[1][0]
-    assert_equal nil,                     tokens[1][1]
-    assert_equal nil,                     tokens[2][0]
+    assert_nil                      tokens[1][1]
+    assert_nil                      tokens[2][0]
     assert_equal '>content',              tokens[2][1]
     
     tokens = 'content<{{cms:type:label }}>content'.scan(regex)
-    assert_equal nil,                     tokens[0][0]
+    assert_nil                      tokens[0][0]
     assert_equal 'content<',              tokens[0][1]
     assert_equal '{{cms:type:label }}',   tokens[1][0]
-    assert_equal nil,                     tokens[1][1]
-    assert_equal nil,                     tokens[2][0]
+    assert_nil                      tokens[1][1]
+    assert_nil                      tokens[2][0]
     assert_equal '>content',              tokens[2][1]
     
     tokens = 'content<{{ cms:type:la/b el }}>content'.scan(regex)
-    assert_equal nil,                     tokens[0][0]
+    assert_nil                      tokens[0][0]
     assert_equal 'content<',              tokens[0][1]
     assert_equal '{{ cms:type:la/b el }}',tokens[1][0]
-    assert_equal nil,                     tokens[1][1]
-    assert_equal nil,                     tokens[2][0]
+    assert_nil                      tokens[1][1]
+    assert_nil                      tokens[2][0]
     assert_equal '>content',              tokens[2][1]
   end
   
@@ -62,7 +62,7 @@ class TagTest < ActiveSupport::TestCase
     string = '<p>text</p>' * 400
     tokens = string.scan(ComfortableMexicanSofa::Tag::TOKENIZER_REGEX)
     assert_equal 1, tokens.count
-    assert_equal nil, tokens[0][0]
+    assert_nil  tokens[0][0]
     assert_equal string, tokens[0][1]
   end
   
@@ -285,7 +285,7 @@ class TagTest < ActiveSupport::TestCase
       comfy_cms_pages(:default), '{{ cms:page:content:string }}'
     )
     assert_equal 'content', tag.identifier
-    assert_equal nil, tag.namespace
+    assert_nil  tag.namespace
     
     assert tag = ComfortableMexicanSofa::Tag::PageString.initialize_tag(
       comfy_cms_pages(:default), '{{ cms:page:home.content:string }}'

--- a/test/lib/tags/helper_test.rb
+++ b/test/lib/tags/helper_test.rb
@@ -62,7 +62,7 @@ class HelperTagTest < ActiveSupport::TestCase
         comfy_cms_pages(:default), "{{ cms:helper:#{method}:Rails.env }}"
       )
       assert_equal "<%= #{method}('Rails.env') %>", tag.content
-      assert_equal nil, tag.render
+      assert_nil  tag.render
     end
   end
   
@@ -80,7 +80,7 @@ class HelperTagTest < ActiveSupport::TestCase
       comfy_cms_pages(:default), "{{ cms:helper:invalid:Rails.env }}"
     )
     assert_equal "<%= invalid('Rails.env') %>", tag.content
-    assert_equal nil, tag.render
+    assert_nil  tag.render
   end
   
 end

--- a/test/lib/tags/page_file_test.rb
+++ b/test/lib/tags/page_file_test.rb
@@ -9,7 +9,7 @@ class PageFileTagTest < ActiveSupport::TestCase
     assert_equal 'label', tag.identifier
     assert_nil tag.namespace
     assert 'url', tag.type
-    assert_equal nil, tag.dimensions
+    assert_nil  tag.dimensions
     
     assert tag = ComfortableMexicanSofa::Tag::PageFile.initialize_tag(
       comfy_cms_pages(:default), '{{ cms:page_file:label:partial }}'
@@ -50,7 +50,7 @@ class PageFileTagTest < ActiveSupport::TestCase
     assert_equal "<%= render :partial => 'partials/page_file', :locals => {:identifier => nil} %>", tag.render
     
     assert tag = ComfortableMexicanSofa::Tag::PageFile.initialize_tag(page, '{{ cms:page_file:file }}')
-    assert_equal nil, tag.content
+    assert_nil  tag.content
     assert_equal '', tag.render
     
     page.update_attributes!(

--- a/test/lib/tags/page_files_test.rb
+++ b/test/lib/tags/page_files_test.rb
@@ -8,8 +8,8 @@ class PageFilesTagTest < ActiveSupport::TestCase
     )
     assert 'url', tag.type
     assert_equal 'label', tag.identifier
-    assert_equal nil, tag.namespace
-    assert_equal nil, tag.dimensions
+    assert_nil  tag.namespace
+    assert_nil  tag.dimensions
     
     assert tag = ComfortableMexicanSofa::Tag::PageFiles.initialize_tag(
       comfy_cms_pages(:default), '{{ cms:page_files:label:partial }}'

--- a/test/lib/tags/partial_test.rb
+++ b/test/lib/tags/partial_test.rb
@@ -70,7 +70,7 @@ class PartialTagTest < ActiveSupport::TestCase
       comfy_cms_pages(:default), '{{cms:partial:unsafe/path}}'
     )
     assert_equal "<%= render :partial => 'unsafe/path' %>", tag.content
-    assert_equal nil, tag.render
+    assert_nil  tag.render
   end
   
 end

--- a/test/lib/tags/snippet_test.rb
+++ b/test/lib/tags/snippet_test.rb
@@ -39,7 +39,7 @@ class SnippetTagTest < ActiveSupport::TestCase
     tag = ComfortableMexicanSofa::Tag::Snippet.initialize_tag(
       comfy_cms_pages(:default), "{{cms:snippet:doesnot_exist}}"
     )
-    assert_equal nil, tag.content
+    assert_nil  tag.content
     assert_equal '', tag.render
   end
 end

--- a/test/lib/tags/template_test.rb
+++ b/test/lib/tags/template_test.rb
@@ -50,7 +50,7 @@ class TemplateTagTest < ActiveSupport::TestCase
       comfy_cms_pages(:default), '{{cms:template:unsafe/path}}'
     )
     assert_equal "<%= render :template => 'unsafe/path' %>", tag.content
-    assert_equal nil, tag.render
+    assert_nil  tag.render
   end
 
 end

--- a/test/models/block_test.rb
+++ b/test/models/block_test.rb
@@ -100,7 +100,7 @@ class CmsBlockTest < ActiveSupport::TestCase
       assert_equal 1, page.blocks.count
       block = page.blocks.first
       assert_equal 'file', block.identifier
-      assert_equal nil, block.content
+      assert_nil  block.content
       assert_equal 1, block.files.count
       assert_equal 'image.jpg', block.files.first.file_file_name
 
@@ -143,7 +143,7 @@ class CmsBlockTest < ActiveSupport::TestCase
         assert_equal 1, page.blocks.count
         block = page.blocks.first
         assert_equal 'files', block.identifier
-        assert_equal nil, block.content
+        assert_nil  block.content
         assert_equal 2, block.files.count
         assert_equal ['image.jpg', 'image.gif'], block.files.collect(&:file_file_name)
       end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -84,12 +84,17 @@ class CmsPageTest < ActiveSupport::TestCase
         :parent => comfy_cms_pages(:default),
         :layout => comfy_cms_layouts(:default),
         :blocks_attributes => [
-          { :identifier => 'default_page_text',
-            :content    => 'test' }
+          {
+            :identifier => 'default_page_text',
+            :content    => 'test',
+            :processed_content => '<p>default_page_text</p>'
+          }
         ]
       )
       assert page.is_published?
       assert_equal 1, page.position
+      assert_equal page.blocks.first[:processed_content], '<p>default_page_text</p>'
+
     end
   end
 

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -107,7 +107,7 @@ class CmsSiteTest < ActiveSupport::TestCase
   def test_find_site
     site_a = comfy_cms_sites(:default)
     assert_equal 'test.host', site_a.hostname
-    assert_equal nil, site_a.path
+    assert_nil  site_a.path
 
     assert_equal site_a, Comfy::Cms::Site.find_site('test.host')
     assert_equal site_a, Comfy::Cms::Site.find_site('test.host', '/some/path')
@@ -119,18 +119,18 @@ class CmsSiteTest < ActiveSupport::TestCase
     assert_equal site_a,  Comfy::Cms::Site.find_site('test.host')
     assert_equal site_a,  Comfy::Cms::Site.find_site('test.host', '/some/path')
     assert_equal site_a,  Comfy::Cms::Site.find_site('test.host', '/some/path')
-    assert_equal nil,     Comfy::Cms::Site.find_site('test99.host', '/some/path')
+    assert_nil      Comfy::Cms::Site.find_site('test99.host', '/some/path')
 
-    assert_equal nil,     Comfy::Cms::Site.find_site('test2.host')
-    assert_equal nil,     Comfy::Cms::Site.find_site('test2.host', '/some/path')
-    assert_equal nil,     Comfy::Cms::Site.find_site('test2.host', '/some/path/en')
-    assert_equal nil,     Comfy::Cms::Site.find_site('test2.host', '/some/preview/en/some/path?a=b')
+    assert_nil      Comfy::Cms::Site.find_site('test2.host')
+    assert_nil      Comfy::Cms::Site.find_site('test2.host', '/some/path')
+    assert_nil      Comfy::Cms::Site.find_site('test2.host', '/some/path/en')
+    assert_nil      Comfy::Cms::Site.find_site('test2.host', '/some/preview/en/some/path?a=b')
     assert_equal site_b,  Comfy::Cms::Site.find_site('test2.host', '/en')
     assert_equal site_b,  Comfy::Cms::Site.find_site('test2.host', '/en?a=b')
     assert_equal site_b,  Comfy::Cms::Site.find_site('test2.host', '/en/some/path?a=b')
     assert_equal site_b,  Comfy::Cms::Site.find_site('test2.host', '/preview/en/some/path?a=b')
 
-    assert_equal nil,     Comfy::Cms::Site.find_site('test2.host', '/english/some/path')
+    assert_nil      Comfy::Cms::Site.find_site('test2.host', '/english/some/path')
 
     assert_equal site_c,  Comfy::Cms::Site.find_site('test2.host', '/fr')
     assert_equal site_c,  Comfy::Cms::Site.find_site('test2.host', '/fr?a=b')


### PR DESCRIPTION
This is related to moneyadviceservice/cms#372

In order to the the CMS PR works I needed to add the line on the manageable module on comfy.

IMHO this module is absolutely unnecessary because we can move to the PageRegister but it is not scope for the cache work so I will add a card to return on this tech debt.