### PR TITLE
scope for searching the page title

### DIFF
--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -117,6 +117,10 @@ class Comfy::Cms::Page < ActiveRecord::Base
     find_by_slug(slug) || find_by_full_path!("/" + slug)
   }
 
+  scope :with_title_like, ->(phrase) {
+    where("#{table_name}.label LIKE ?", "%#{phrase}%")
+  }
+
   # These scopes are to be used with the Filtrable module
   scope :category, ->(category) { includes(:categories).for_category(category) }
   scope :layout, ->(layout) { joins(:layout).merge(Comfy::Cms::Layout.where(identifier: layout)) }

--- a/test/models/page/with_title_like_scope_test.rb
+++ b/test/models/page/with_title_like_scope_test.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+
+require_relative '../../test_helper'
+
+class CmsPageScopeTest < ActiveSupport::TestCase
+  include FactoryGirl::Syntax::Methods
+
+  # Pages with state 'published' should NOT be returned
+  def test_page_with_title_like
+    label1 = 'Financial well being: the employee view'
+    label2 = 'Financial well being: the employer view'
+    phrase = 'the employee view'
+    
+    FactoryGirl.create(:page, site: test_site, state: 'published', slug: 'slug', label: label1)
+    FactoryGirl.create(:page, site: test_site, state: 'published', slug: 'slug', label: label2)
+
+    assert_equal 1, test_site.pages.with_title_like(phrase).count
+  end
+
+  private
+
+  # A site is used here to allow us to use factories
+  # and keep them separate to fixture data
+  def test_site
+    @test_site ||= FactoryGirl.create(:site)
+  end
+
+end


### PR DESCRIPTION
[TP 8997](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/8997)

The FinCap search facility requires that page titles are searched for specific content. This pr adds a method that facilitates the CMS serving the FinCap search request.

### Technical
* Add a scope to the page model, `with_title_like`
* The CMS can use this scope for searching through page titles e.g. `pages.published.with_title_like(search_term)`