### PR TITLE
Remove validates uniqueness of block identifiers

### DIFF
--- a/app/models/comfy/cms/block.rb
+++ b/app/models/comfy/cms/block.rb
@@ -13,9 +13,7 @@ class Comfy::Cms::Block < ActiveRecord::Base
   before_save :prepare_files
 
   # -- Validations ----------------------------------------------------------
-  validates :identifier,
-    :presence   => true,
-    :uniqueness => { :scope => [:blockable_type, :blockable_id] }
+  validates :identifier, :presence => true
 
   # -- Instance Methods -----------------------------------------------------
   # Tag object that is using this block


### PR DESCRIPTION
This line was blocking to be possible to create pages
with multiple properties as an example:

```
Comfy::Cms::Page.new(
  blocks: [
    Comfy::Cms::Block.new(
      identifier: 'client_groups',
      content: 'Working age (18 - 65)'
    ),
    Comfy::Cms::Block.new(
      identifier: 'client_groups',
      content: 'Over-indebted people'
    )
  ]
)
```