### PR TITLE
Set explicit test dependency on Nokogiri 1.6.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,5 @@ group :test do
   gem 'database_cleaner'
   gem 'faker', '~> 1.7'
   gem 'pry-byebug'
+  gem 'nokogiri', '~>1.6.0'
 end


### PR DESCRIPTION
Our current stack in Go Pipelines uses a very old of LibXML2, this
causes issues when using Nokogiri over 1.6 (1.7 or 1.8) as when parsing
websites removes the expected return carriages and causes assertions
failing.

There are plans to upgrade Go Pipelines environments so a more modern
LibXML2 version is used and we can upgrade to Nokogiri newer versions,
but until that point, we actually depend on using 1.6 version.

This commit raises/sets that explicit dependency.