### PR TITLE
Update jenkins config for bundled base image

### DIFF
--- a/comfortable_mexican_sofa.gemspec
+++ b/comfortable_mexican_sofa.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.platform      = Gem::Platform::RUBY
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.5.3'
 
   s.add_dependency 'rails',             '>= 4.0.0', '<= 5'
   s.add_dependency 'rails-i18n',        '>= 4.0.0'

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,9 +1,9 @@
-FROM masdevtestregistry.azurecr.io/jenkins/ruby2.5.3:latest
-MAINTAINER development.team@moneyadviceservice.org.uk
+FROM masdevtestregistry.azurecr.io/jenkins/sfgb-bundle-2.5.3:latest
 
 RUN apt-get -qq update > /dev/null && \
   apt-get -qq dist-upgrade > /dev/null && \
   apt-get -qq clean  > /dev/null && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY . /var/tmp/app/
+WORKDIR /var/tmp/app/
+COPY . .

--- a/jenkins/build
+++ b/jenkins/build
@@ -9,7 +9,6 @@ fi
 
 export RAILS_ENV=build
 export BUNDLE_WITHOUT="development:test"
-exit_code=0
 
 function run {
     declare -a build_command=("$@")
@@ -17,12 +16,10 @@ function run {
     echo "=== Running \`${build_command[*]}\`"
     if ! ${build_command[*]}; then
         echo "=== This build failed."
-        exit_code=1
+        exit 1
     fi
 }
 run bundle install
 run bowndler install --production --allow-root
 run gem build *.gemspec
 run gem inabox *.gem -g http://gems.dev.mas.local
-
-exit "$exit_code"

--- a/jenkins/test
+++ b/jenkins/test
@@ -10,8 +10,6 @@ fi
 export RAILS_ENV=test
 export BUNDLE_WITHOUT=development:build
 
-exit_code=0
-
 function run {
     declare -a tests_command=("$@")
 
@@ -19,7 +17,7 @@ function run {
     echo "=== Running \`${tests_command[*]}\`"
     if ! ${tests_command[*]}; then
         echo "=== These tests failed."
-        exit_code=1
+        exit 1
     fi
 }
 
@@ -32,7 +30,7 @@ function info {
     fi
 }
 
-run bundle install --quiet
+run bundle install
 run bundle exec rake db:drop db:create db:migrate
 run bundle exec rake test
 info bundle exec brakeman -q --no-pager --ensure-latest
@@ -40,5 +38,3 @@ info bundle exec brakeman -q --no-pager --ensure-latest
 if [ -f /.dockerenv ]; then
   run bundle exec danger --dangerfile=jenkins/Dangerfile --verbose
 fi
-
-exit "$exit_code"


### PR DESCRIPTION
In an effort to increase efficiency and speed, we can now use a pre-bundled Docker image which includes all gems & dependancies.

Changes include;

- Use Pre-bundled base image in Jenkins
- Updates to test script